### PR TITLE
Use Model 2.0-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "require": {
         "php": ">=5.3.10",
         "joomla/filesystem": "~1.0",
-        "joomla/model": "~1.0"
+        "joomla/model": "~2.0@dev"
     },
     "require-dev": {
         "joomla/test": "~1.0",


### PR DESCRIPTION
In keeping with 2.x branch (and Registry), View requires joomla/model in 1.x, which requires joomla/registry ~1.0.
So we have a version conflict.
Is it possible to switch to 2.0-dev branch for Model ?