### PR TITLE
Deprecate the dependency to joomla/model

### DIFF
--- a/src/AbstractView.php
+++ b/src/AbstractView.php
@@ -22,6 +22,7 @@ abstract class AbstractView implements ViewInterface
 	 *
 	 * @var    ModelInterface
 	 * @since  1.0
+	 * @deprecated  2.0  A view object will not require a ModelInterface implementation
 	 */
 	protected $model;
 
@@ -31,8 +32,9 @@ abstract class AbstractView implements ViewInterface
 	 * @param   ModelInterface  $model  The model object.
 	 *
 	 * @since   1.0
+	 * @deprecated  2.0  A view object will not require a ModelInterface implementation
 	 */
-	public function __construct(ModelInterface $model)
+	public function __construct(ModelInterface $model = null)
 	{
 		// Setup dependencies.
 		$this->model = $model;


### PR DESCRIPTION
`Joomla\Model\ModelInterface` is now deprecated and there isn't a hard requirement for models to implement either the stateful or database interfaces.  This PR therefore deprecates the requirement for a `Joomla\Model\ModelInterface` to be injected into a view.  The constructor argument will be optional through the rest of 1.x and in 2.0 the constructor will be removed completely.